### PR TITLE
Fix @Override method deprecated in RN 0.47

### DIFF
--- a/android/src/main/java/com/packetzoom/RNPacketzoom/RNPacketzoom.java
+++ b/android/src/main/java/com/packetzoom/RNPacketzoom/RNPacketzoom.java
@@ -23,7 +23,6 @@ public class RNPacketzoom implements ReactPackage {
         return modules;
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
_error: method does not override or implement a method from a supertype_

Breaking change in RN 0.47 (facebook/react-native@ce6fb33) causes Android compilation to fail.