### PR TITLE
requiresMainQueueSetup on RNPacketzoom.m

### DIFF
--- a/RNPacketzoom/RNPacketzoom/RNPacketzoom.m
+++ b/RNPacketzoom/RNPacketzoom/RNPacketzoom.m
@@ -21,7 +21,7 @@ RCT_EXPORT_MODULE()
 
 - (id) init {
     self = [super init];
-    
+
     return self;
 }
 
@@ -39,8 +39,13 @@ RCT_EXPORT_MODULE()
 RCT_EXPORT_METHOD(init:(NSString *)appId apiKey:(NSString *)apiKey)
 {
     NSLog(@"RNPacketzoom init version = %ld",  [PZSpeedController version]);
-   
+
     [PZSpeedController controllerWithAppID: appId apiKey: apiKey];
+}
+
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
 }
 
 @end


### PR DESCRIPTION
Added requiresMainQueueSetup to prevent warning

Module RNFIRAnalytics requires main queue setup since it overrides constantsToExport but doesn't implement `requiresMainQueueSetup. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of.